### PR TITLE
Allow manually triggering the workflow

### DIFF
--- a/.github/workflows/schedules.yml
+++ b/.github/workflows/schedules.yml
@@ -1,5 +1,6 @@
 name: update awesome-stars
 on:
+  workflow_dispatch:
   schedule:
   - cron: 30 0 * * *
 jobs:


### PR DESCRIPTION
This is useful when you first use this template, and the first run won't happen before the next schedule time, but you still want to see the results immediately.

cf. https://medium.com/@knoldus/manual-trigger-in-github-actions-da80cd126b71